### PR TITLE
es locale, opensearch resources and dialog resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Предоставляет расширенные возможности по управлению поисковыми плагинами **Firefox**:
 * создание папок
 * создание разделителей
+* доступ к онлайн-ресурсам для загрузки и создания/загрузки поисковых плагинов
 * изменение порядка плагинов в списке
 * редактирование и удаление плагинов
 * поиск во всех плагинах папки нажатием одной кнопки
@@ -21,9 +22,10 @@
 Provides advanced features for managing search plug-ins in **Firefox**:
 * creating folders
 * creating separators
+* accessing online resources to download and create/upload search plugins
 * changing the order of plugins in the list
 * editing and deleting plugins
-* search in all plug-ins folder with the click of a button
+* search with all search plugins in a folder with the click of a button
 
 The author of the original extension is Malte Kraus.
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,21 @@
 Последняя версия расширения подписанная Mozilla: [organize-search-engines_x.xx-**fx**.xpi] (https://github.com/Baton34/organize-search-engines/releases/latest)
 
 Перед установкой версии 1.95.5 и выше удалите предыдущую версию (1.95.2 и ниже).
+
+
+
+# "Organize Search Engines" extension for Firefox
+(Translated 2017-09-13)
+
+Provides advanced features for managing search plug-ins in **Firefox**:
+* creating folders
+* creating separators
+* changing the order of plugins in the list
+* editing and deleting plugins
+* search in all plug-ins folder with the click of a button
+
+The author of the original extension is Malte Kraus.
+
+The latest version of the extension signed by Mozilla can be found here: [organize-search-engines_x.xx - **fx**. Xpi] (https://github.com/Baton34/organize-search-engines/releases/latest)
+
+Before installing a version 1.95.5 or higher, delete any previous version 1.95.2 and below.

--- a/content/engineManager.js
+++ b/content/engineManager.js
@@ -22,6 +22,7 @@ the Initial Developer. All Rights Reserved.
 
 Contributor(s):
   Malte Kraus <mails@maltekraus.de> (Original author)
+  strel
 
  Alternatively, the contents of this file may be used under the terms of
  either the GNU General Public License Version 2 or later (the "GPL"), or
@@ -572,6 +573,45 @@ EngineManagerDialog.prototype = {
               .getMostRecentWindow("navigator:browser");
     }
     win.BrowserSearch.loadAddEngines();
+    window.close();
+    win.focus();
+  },
+       
+  loadAddEnginesMP: function EngineManager__loadAddEnginesMP() {
+    this.onOK();
+    var win = window.opener;
+    if(!("BrowserSearch" in win)) {
+      win = Cc["@mozilla.org/appshell/window-mediator;1"]
+              .getService(Ci.nsIWindowMediator)
+              .getMostRecentWindow("navigator:browser");
+    }
+    win.gBrowser.addTab("http://www.mycroftproject.com/search-engines.html");
+    window.close();
+    win.focus();
+  },
+  
+  loadGenerator7is7: function EngineManager__loadGenerator7is7() {
+    this.onOK();
+    var win = window.opener;
+    if(!("BrowserSearch" in win)) {
+      win = Cc["@mozilla.org/appshell/window-mediator;1"]
+              .getService(Ci.nsIWindowMediator)
+              .getMostRecentWindow("navigator:browser");
+    }
+    win.gBrowser.addTab("http://7is7.com/software/firefox/opensearch.html");
+    window.close();
+    win.focus();
+  },
+  
+  loadGeneratorR2S: function EngineManager__loadGeneratorR2S() {
+    this.onOK();
+    var win = window.opener;
+    if(!("BrowserSearch" in win)) {
+      win = Cc["@mozilla.org/appshell/window-mediator;1"]
+              .getService(Ci.nsIWindowMediator)
+              .getMostRecentWindow("navigator:browser");
+    }
+    win.gBrowser.addTab("http://ready.to/search/en/");
     window.close();
     win.focus();
   },

--- a/content/engineManager.xul
+++ b/content/engineManager.xul
@@ -21,6 +21,7 @@ the Initial Developer. All Rights Reserved.
 
 Contributor(s):
   Malte Kraus <mails@maltekraus.de> (Original author)
+  strel
 
  Alternatively, the contents of this file may be used under the terms of
  either the GNU General Public License Version 2 or later (the "GPL"), or
@@ -123,14 +124,14 @@ Contributor(s):
       <menuitem label="&dn.label;" accesskey="&noconflict.dn.accesskey;"
                 id="context-down" command="cmd_movedown" />
       <menuseparator />
-      <menu id="context-new" label="&context.new.label;" accesskey="&context.new.accesskey;">
-        <menupopup>
+<!--      <menu id="context-new" label="&context.new.label;" accesskey="&context.new.accesskey;">
+        <menupopup> -->
           <menuitem label="&new-folder.label;" accesskey="&new-folder.accesskey;"
                     id="context-new-folder" command="cmd_new-folder" />
           <menuitem label="&new-separator.label;" accesskey="&new-separator.accesskey;"
                     id="context-new-separator" command="cmd_new-separator" />
-        </menupopup>
-      </menu>
+<!--        </menupopup>
+      </menu> -->
       <menuitem key="key_remove" label="&remove.label;" accesskey="&noconflict.remove.accesskey;"
                 id="context-remove" command="cmd_remove" />
       <menuseparator />
@@ -153,6 +154,15 @@ Contributor(s):
           <menuitem id="addEngines" label="&addEngine.label;"
                     accesskey="&addEngine.accesskey;"
                     oncommand="gEngineManagerDialog.loadAddEngines();" />
+          <menuitem id="addEnginesMP" label="&addEngineMP.label;"
+                    accesskey="&addEngineMP.accesskey;"
+                    oncommand="gEngineManagerDialog.loadAddEnginesMP();" />
+          <menuitem id="openGenerator7is7" label="&openGen7is7.label;"
+                    accesskey="&openGen7is7.accesskey;"
+                    oncommand="gEngineManagerDialog.loadGenerator7is7();" />
+          <menuitem id="openGeneratorR2S" label="&openGenR2S.label;"
+                    accesskey="&openGenR2S.accesskey;"
+                    oncommand="gEngineManagerDialog.loadGeneratorR2S();" />
           <menuitem id="restoreDefault" label="&restoreDefault.label;"
                     accesskey="&restoreDefault.accesskey;"
                     oncommand="gEngineManagerDialog.newItem(gEngineManagerDialog.NEW_ITEM_RESTORED_DEFAULT_ENGINE);" />

--- a/content/moveTo.xul
+++ b/content/moveTo.xul
@@ -21,6 +21,7 @@ the Initial Developer. All Rights Reserved.
 
 Contributor(s):
   Malte Kraus <mails@maltekraus.de> (Original author)
+  strel
 
  Alternatively, the contents of this file may be used under the terms of
  either the GNU General Public License Version 2 or later (the "GPL"), or
@@ -37,6 +38,7 @@ Contributor(s):
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://browser/skin/places/places.css"?>
 <?xml-stylesheet href="chrome://global/skin/tree.css"?>
+<?xml-stylesheet href="chrome://seorganizer/skin/moveTo.css"?>
 
 <!DOCTYPE dialog SYSTEM "chrome://seorganizer/locale/moveTo.dtd">
 

--- a/install.rdf
+++ b/install.rdf
@@ -15,6 +15,7 @@
     <em:creator>Malte Kraus</em:creator>
     <em:contributor>ReVox: help sorting out the crash on cancel</em:contributor>
     <em:contributor>Wawuschel: testing, testing, testing</em:contributor>
+    <em:contributor>strel: menus for opensearch resources, Move dialog resizing</em:contributor>
 
     <em:translator>Andrea</em:translator>
     <em:translator>Mikes Kaszmán István</em:translator>
@@ -32,7 +33,16 @@
     <em:translator>mrtcvk</em:translator>
     <em:translator>Володимир Савчук Volodymyr Savchuk</em:translator>
     <em:translator>smoke</em:translator>
-
+	
+    <em:localized>
+      <Description>
+        <em:name>Organize Search Engines</em:name>
+        <em:locale>es</em:locale>
+        <em:description>Organice sus motores de búsqueda con separadores y carpetas.</em:description>
+        <em:translator>strel</em:translator>
+      </Description>
+    </em:localized>
+		
     <em:targetApplication>
       <RDF:Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>

--- a/locale/ca/engineManager.dtd
+++ b/locale/ca/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Nom">
 <!ENTITY aliascol.label "Paraula clau">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "Restaura el motor predeterminat">
 <!ENTITY restoreDefault.accesskey "R">
 <!ENTITY new-folder.label "Carpeta nova...">
@@ -54,11 +53,17 @@
 <!ENTITY  edit.label                "Edita la paraula clau…">
 <!ENTITY  edit.accesskey            "t">
 
-<!ENTITY  addEngine.label           "Aconsegueix més motors de cerca…">
-<!ENTITY  addEngine.accesskey       "A">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Mostra suggeriments de cerca">
-<!ENTITY  enableSuggest.accesskey   "s">
+<!ENTITY  enableSuggest.accesskey   "u">
 
 <!ENTITY  restoreDefaults.label     "Restaura els motors per defecte">
 <!ENTITY  restoreDefaults.accesskey "e">

--- a/locale/de/engineManager.dtd
+++ b/locale/de/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Name">
 <!ENTITY aliascol.label "Schlüsselwort">
-<!ENTITY addEngine.accesskey "M">
 <!ENTITY restoreDefault.label "Vorgabe wiederherstellen">
 <!ENTITY restoreDefault.accesskey "V">
 <!ENTITY new-folder.label "Neuer Ordner…">
@@ -54,8 +53,14 @@
 <!ENTITY  edit.label                "Schlüsselwort bearbeiten…">
 <!ENTITY  edit.accesskey            "b">
 
-<!ENTITY  addEngine.label           "Weitere Suchmaschinen hinzufügen…">
-<!ENTITY  addEngine.accesskey       "W">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Suchvorschläge anzeigen">
 <!ENTITY  enableSuggest.accesskey   "S">

--- a/locale/en-GB/engineManager.dtd
+++ b/locale/en-GB/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Name">
 <!ENTITY aliascol.label "Keyword">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "Restore Default Engine">
 <!ENTITY restoreDefault.accesskey "e">
 <!ENTITY new-folder.label "New Folder">
@@ -54,11 +53,17 @@
 <!ENTITY  edit.label                "Edit Keyword…">
 <!ENTITY  edit.accesskey            "t">
 
-<!ENTITY  addEngine.label           "Get more search engines…">
-<!ENTITY  addEngine.accesskey       "a">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Show search suggestions">
-<!ENTITY  enableSuggest.accesskey   "S">
+<!ENTITY  enableSuggest.accesskey   "u">
 
 <!ENTITY  restoreDefaults.label     "Restore Defaults">
 <!ENTITY  restoreDefaults.accesskey "e">

--- a/locale/en-US/engineManager.dtd
+++ b/locale/en-US/engineManager.dtd
@@ -1,9 +1,8 @@
 <!ENTITY namecol.label            "Name">
 <!ENTITY aliascol.label           "Keyword">
 
-<!ENTITY addEngine.accesskey      "G">
 <!ENTITY restoreDefault.label     "Restore Default Engine">
-<!ENTITY restoreDefault.accesskey "e">
+<!ENTITY restoreDefault.accesskey "R">
 
 <!ENTITY new-folder.label         "New Folder">
 <!ENTITY new-folder.accesskey     "F">
@@ -58,9 +57,15 @@
 <!ENTITY  remove.accesskey          "R">
 <!ENTITY  edit.label                "Edit Keyword…">
 <!ENTITY  edit.accesskey            "t">
-<!ENTITY  addEngine.label           "Get more search engines…">
-<!ENTITY  addEngine.accesskey       "A">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 plugin generator">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator">
+<!ENTITY  openGenR2S.accesskey      "2">
 <!ENTITY  enableSuggest.label       "Show search suggestions">
-<!ENTITY  enableSuggest.accesskey   "S">
+<!ENTITY  enableSuggest.accesskey   "u">
 <!ENTITY  restoreDefaults.label     "Restore Defaults">
 <!ENTITY  restoreDefaults.accesskey "e">

--- a/locale/es/confirmAddEngine.dtd
+++ b/locale/es/confirmAddEngine.dtd
@@ -1,0 +1,3 @@
+<!ENTITY searchEngines              "Motores de búsqueda">
+<!ENTITY createin.label             "Crear en:">
+<!ENTITY createin.accesskey         "C">

--- a/locale/es/desc.properties
+++ b/locale/es/desc.properties
@@ -1,0 +1,1 @@
+extensions.organize-search-engines@maltekraus.de.description=Organice sus motores de búsqueda con separadores y carpetas.

--- a/locale/es/engineManager.dtd
+++ b/locale/es/engineManager.dtd
@@ -1,0 +1,71 @@
+<!ENTITY namecol.label            "Nombre">
+<!ENTITY aliascol.label           "Palabra clave">
+
+<!ENTITY restoreDefault.label     "Restaurar motor predeterminado">
+<!ENTITY restoreDefault.accesskey "R">
+
+<!ENTITY new-folder.label         "Nueva carpeta">
+<!ENTITY new-folder.accesskey     "c">
+<!ENTITY new-separator.label      "Nuevo separador">
+<!ENTITY new-separator.accesskey  "s">
+
+<!ENTITY move-engine.label        "Mover a carpeta">
+<!ENTITY move-engine.accesskey    "M">
+
+<!ENTITY rename.label             "Renombrar">
+<!ENTITY rename.accesskey         "R">
+<!ENTITY editalias.label          "Editar palabra clave">
+<!ENTITY editalias.accesskey      "d">
+<!ENTITY properties.label         "Propiedades">
+<!ENTITY properties.accesskey     "P">
+
+<!ENTITY context.new.label        "Nuevo/a">
+<!ENTITY context.new.accesskey    "N">
+
+<!ENTITY noconflict.enableSuggest.accesskey "&enableSuggest.accesskey;">
+<!ENTITY noconflict.remove.accesskey        "&remove.accesskey;">
+<!ENTITY noconflict.up.accesskey            "&up.accesskey;">
+<!ENTITY noconflict.dn.accesskey            "&dn.accesskey;">
+
+<!ENTITY fileMenu.label           "Archivo">
+<!ENTITY fileMenu.accesskey       "A">
+<!ENTITY closeCmd.label           "Cerrar">
+<!ENTITY closeCmd.accesskey       "e">
+<!ENTITY viewMenu.label           "Ver">
+<!ENTITY viewMenu.accesskey       "V">
+<!ENTITY menuitem.view.command.toolbar.label     "Barra de herramientas">
+<!ENTITY menuitem.view.command.toolbar.accesskey "B">
+<!ENTITY menuitem.view.show_columns.label        "Mostrar columnas">
+<!ENTITY menuitem.view.show_columns.accesskey    "M">
+<!ENTITY menuitem.view.unsorted.label            "Desordenada">
+<!ENTITY menuitem.view.unsorted.accesskey        "s">
+<!ENTITY sortAscending.label                     "Ascendente">
+<!ENTITY sortAscending.accesskey                 "A">
+<!ENTITY sortDescending.label                    "Descendente">
+<!ENTITY sortDescending.accesskey                "D">
+<!ENTITY  engineManager.title       "Administrar lista de motores de búsqueda">
+<!ENTITY  engineManager.style       "min-width: 35em;">
+<!ENTITY  engineManager.intro       "Tiene instalados los siguientes motores:">
+<!ENTITY  columnLabel.name          "Nombre">
+<!ENTITY  columnLabel.keyword       "Palabra clave">
+<!-- Buttons -->
+<!ENTITY  up.label                  "Mover arriba">
+<!ENTITY  up.accesskey              "a">
+<!ENTITY  dn.label                  "Mover abajo">
+<!ENTITY  dn.accesskey              "b">
+<!ENTITY  remove.label              "Eliminar">
+<!ENTITY  remove.accesskey          "E">
+<!ENTITY  edit.label                "Editar palabra clave">
+<!ENTITY  edit.accesskey            "d">
+<!ENTITY  addEngine.label           "Obtener plugins de Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Obtener plugins de Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "Generador de plugins 7is7 (avanzado)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Generador de plugins Ready2Search (avanzado)">
+<!ENTITY  openGenR2S.accesskey      "2">
+<!ENTITY  enableSuggest.label       "Mostrar sugerencias de búsqueda">
+<!ENTITY  enableSuggest.accesskey   "u">
+<!ENTITY  restoreDefaults.label     "Restaurar valores predeterminados">
+<!ENTITY  restoreDefaults.accesskey "e">

--- a/locale/es/engineManager.properties
+++ b/locale/es/engineManager.properties
@@ -1,0 +1,11 @@
+new-folder.title=Nueva carpeta
+new-folder.name=El nombre de la nueva carpeta:
+
+editalias.title=Editar palabra clave de "%1$S"
+editalias.name=Palabra clave de "%1$S":
+
+rename.title=Renombrar "%1$S"
+rename.name=Nuevo nombre de "%1$S":
+
+restore.title=Restaurar motor predeterminado
+restore.content=Seleccione el motor a ser restaurado:

--- a/locale/es/engineProperties.dtd
+++ b/locale/es/engineProperties.dtd
@@ -1,0 +1,57 @@
+<!ENTITY engineProperties.title "Propiedades del motor">
+
+<!ENTITY prop.name.label     "Nombre:">
+<!ENTITY prop.name.accesskey "N">
+
+<!ENTITY prop.icon.label     "Icono:">
+
+<!ENTITY prop.icon.browse.label     "Examinar…">
+<!ENTITY prop.icon.browse.accesskey "E">
+
+<!ENTITY prop.icon.download.label     "Descargar automáticamente">
+<!ENTITY prop.icon.download.accesskey "D">
+
+<!ENTITY prop.keyword.label     "Palabra clave:">
+<!ENTITY prop.keyword.accesskey "P">
+
+<!ENTITY prop.description.label     "Descripción:">
+<!ENTITY prop.description.accesskey "s">
+
+<!ENTITY prop.homepage.label     "Página principal:">
+<!ENTITY prop.homepage.accesskey "g">
+
+<!ENTITY prop.searchurl.label     "URL de búsqueda:">
+<!ENTITY prop.searchurl.accesskey "b">
+
+<!ENTITY prop.encoding.label     "Codificación:">
+<!ENTITY prop.encoding.accesskey "C">
+
+<!ENTITY prop.httpmethod.label     "Método HTTP:">
+<!ENTITY prop.httpmethod.accesskey "M">
+
+<!ENTITY prop.parameter.label            "Parámetro:">
+<!ENTITY prop.parameter.accesskey        "r">
+<!ENTITY prop.parameter.add.label        "Añadir:">
+<!ENTITY prop.parameter.add.accesskey    "A">
+<!ENTITY prop.parameter.remove.label     "Eliminar:">
+<!ENTITY prop.parameter.remove.accesskey "E">
+
+<!ENTITY prop.update.url.label     "URL de actualización:">
+<!ENTITY prop.update.url.accesskey "a">
+
+<!ENTITY prop.update.datatype.label     "Tipo de datos de actualización:">
+<!ENTITY prop.update.datatype.accesskey "T">
+
+<!ENTITY prop.update.datatype.openmozsearch.label     "OpenSearch o MozSearch">
+<!ENTITY prop.update.datatype.openmozsearch.accesskey "OM">
+
+<!ENTITY prop.update.datatype.sherlock.label     "Apple Sherlock">
+<!ENTITY prop.update.datatype.sherlock.accesskey "A">
+
+<!ENTITY prop.update.icon.label     "URL de actualización del icono:">
+<!ENTITY prop.update.icon.accesskey "o">
+
+<!ENTITY prop.update.interval.label     "Intervalo de actualización:">
+<!ENTITY prop.update.interval.accesskey "I">
+
+<!ENTITY prop.update.interval.days.label     "días">

--- a/locale/es/engineProperties.properties
+++ b/locale/es/engineProperties.properties
@@ -1,0 +1,5 @@
+fileSizeTitle=El tamaño de fichero excede el máximo
+fileSizeMessage=Para evitar retardos al iniciar Firefox el tamaño de un icono no debe exceder de %1$S KB.\n\nEl icono que escogió tiene un tamaño de %2$S KB.\n\nPor favor, pruebe a reducir el tamaño del fichero o escoja otro icono.
+unsupportedImageTitle=Tipo de fichero de imagen no soportado
+unsupportedImageMessageBrowse=El fichero que escogió no está reconocido por Firefox.
+unsupportedImageMessageDownload=El fichero proporcionado por el sitio web no está reconocido por Firefox.

--- a/locale/es/moveTo.dtd
+++ b/locale/es/moveTo.dtd
@@ -1,0 +1,4 @@
+<!ENTITY window.title            "Mover elemento(s)">
+<!ENTITY move-to.label           "Mover a:">
+<!ENTITY move-to.accesskey       "M">
+<!ENTITY search-engines.toplevel "Motores de búsqueda">

--- a/locale/es/searchbar.dtd
+++ b/locale/es/searchbar.dtd
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!ENTITY cmd_engineManager.label        "Administrar motores de búsqueda…">
+<!ENTITY searchEndCap.label             "Buscar">

--- a/locale/fa/engineManager.dtd
+++ b/locale/fa/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Name">
 <!ENTITY aliascol.label "Keyword">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "Restore Default Engine">
 <!ENTITY restoreDefault.accesskey "e">
 <!ENTITY new-folder.label "New Folder">
@@ -51,8 +50,14 @@
 <!ENTITY  remove.accesskey          "R">
 <!ENTITY  edit.label                "Edit Keyword…">
 <!ENTITY  edit.accesskey            "t">
-<!ENTITY  addEngine.label           "Get more search engines…">
-<!ENTITY  addEngine.accesskey       "A">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 <!ENTITY  enableSuggest.label       "Show search suggestions">
 <!ENTITY  enableSuggest.accesskey   "S">
 <!ENTITY  restoreDefaults.label     "Restore Defaults">

--- a/locale/fr/engineManager.dtd
+++ b/locale/fr/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Nom">
 <!ENTITY aliascol.label "Mot-clé">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "Restaurer le moteur de recherche par défaut">
 <!ENTITY restoreDefault.accesskey "e">
 <!ENTITY new-folder.label "Nouveau dossier…">
@@ -54,8 +53,14 @@
 <!ENTITY  edit.label                "Modifier le mot-clé…">
 <!ENTITY  edit.accesskey            "o">
 
-<!ENTITY  addEngine.label           "Obtenir d'autres moteurs de recherche…">
-<!ENTITY  addEngine.accesskey       "O">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Afficher les suggestions de recherche">
 <!ENTITY  enableSuggest.accesskey   "A">

--- a/locale/he/engineManager.dtd
+++ b/locale/he/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "שם">
 <!ENTITY aliascol.label "מילת מפתח">
-<!ENTITY addEngine.accesskey "י">
 <!ENTITY restoreDefault.label "שחזר מנועי ברירת מחדל">
 <!ENTITY restoreDefault.accesskey "ז">
 <!ENTITY new-folder.label "תיקיה חדשה...">
@@ -54,8 +53,14 @@
 <!ENTITY  edit.label                "עריכת מילת מפתח...">
 <!ENTITY  edit.accesskey            "ע">
 
-<!ENTITY  addEngine.label           "קבלת מנועי חיפוש נוספים...">
-<!ENTITY  addEngine.accesskey       "מ">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "הצגת המלצות חיפוש">
 <!ENTITY  enableSuggest.accesskey   "צ">

--- a/locale/hu/engineManager.dtd
+++ b/locale/hu/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Név">
 <!ENTITY aliascol.label "Kulcsszó">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "Alapértelmezett kereső visszaállítása">
 <!ENTITY restoreDefault.accesskey "A">
 <!ENTITY new-folder.label "Új mappa...">
@@ -54,8 +53,14 @@
 <!ENTITY  edit.label                "Kulcsszó szerkesztése…">
 <!ENTITY  edit.accesskey            "K">
 
-<!ENTITY  addEngine.label           "További keresők letöltése…">
-<!ENTITY  addEngine.accesskey       "T">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Keresési javaslatok megjelenítése">
 <!ENTITY  enableSuggest.accesskey   "K">

--- a/locale/it/engineManager.dtd
+++ b/locale/it/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Nome">
 <!ENTITY aliascol.label "Parola chiave">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "Ripristina predefiniti">
 <!ENTITY restoreDefault.accesskey "e">
 <!ENTITY new-folder.label "Nuova cartella...">
@@ -50,9 +49,15 @@
 <!ENTITY remove.accesskey "R">
 <!ENTITY edit.label "Modifica parola chiave…">
 <!ENTITY edit.accesskey "c">
-<!ENTITY addEngine.label "Altri motori di ricerca…">
-<!ENTITY addEngine.accesskey "A">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 <!ENTITY enableSuggest.label "Mostra i suggerimenti di ricerca">
-<!ENTITY enableSuggest.accesskey "M">
+<!ENTITY enableSuggest.accesskey "u">
 <!ENTITY restoreDefaults.label "Ripristina predefiniti">
 <!ENTITY restoreDefaults.accesskey "n">

--- a/locale/ja/engineManager.dtd
+++ b/locale/ja/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "名前">
 <!ENTITY aliascol.label "キーワード">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "既定のエンジンに戻す">
 <!ENTITY restoreDefault.accesskey "e">
 <!ENTITY new-folder.label "新しいフォルダ...">
@@ -54,11 +53,17 @@
 <!ENTITY  edit.label			"キーワードを編集...">
 <!ENTITY  edit.accesskey		"t">
 
-<!ENTITY  addEngine.label		"検索エンジンを追加...">
-<!ENTITY  addEngine.accesskey		"A">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label		"検索語句の候補を表示する">
-<!ENTITY  enableSuggest.accesskey	"S">
+<!ENTITY  enableSuggest.accesskey	"u">
 
 <!ENTITY  restoreDefaults.label		"初期設定に戻す">
 <!ENTITY  restoreDefaults.accesskey	"e">

--- a/locale/nl/engineManager.dtd
+++ b/locale/nl/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Naam">
 <!ENTITY aliascol.label "Sleutelwoord">
-<!ENTITY addEngine.accesskey "S">
 <!ENTITY restoreDefault.label "Standaard zoekmachine herstellen">
 <!ENTITY restoreDefault.accesskey "h">
 <!ENTITY new-folder.label "Nieuwe map...">
@@ -54,8 +53,14 @@
 <!ENTITY  edit.label                "Sleutelwoord bewerken…">
 <!ENTITY  edit.accesskey            "b">
 
-<!ENTITY  addEngine.label           "Meer zoekmachines verkrijgen…">
-<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "o">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Zoeksuggesties tonen">
 <!ENTITY  enableSuggest.accesskey   "Z">

--- a/locale/pl/engineManager.dtd
+++ b/locale/pl/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Nazwa">
 <!ENTITY aliascol.label "Słowo kluczowe">
-<!ENTITY addEngine.accesskey "W">
 <!ENTITY restoreDefault.label "Przywróć domyślną wyszukiwarkę">
 <!ENTITY restoreDefault.accesskey "r">
 <!ENTITY new-folder.label "Nowy folder...">
@@ -55,8 +54,14 @@
 <!ENTITY  edit.label                "Zmień słowo kluczowe…">
 <!ENTITY  edit.accesskey            "Z">
 
-<!ENTITY  addEngine.label           "Pobierz więcej wyszukiwarek…">
-<!ENTITY  addEngine.accesskey       "P">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Wyświetlaj podpowiedzi wyszukiwania">
 <!ENTITY  enableSuggest.accesskey   "W">

--- a/locale/pt-BR/engineManager.dtd
+++ b/locale/pt-BR/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Nome">
 <!ENTITY aliascol.label "Palavra-chave">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "Restaurar Mecanismo Padrão">
 <!ENTITY restoreDefault.accesskey "e">
 <!ENTITY new-folder.label "Nova Pasta...">
@@ -54,11 +53,17 @@
 <!ENTITY  edit.label                "Palavra-chave…">
 <!ENTITY  edit.accesskey            "P">
 
-<!ENTITY  addEngine.label           "Obter mais mecanismos de pesquisa…">
-<!ENTITY  addEngine.accesskey       "a">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Exibir sugestões">
-<!ENTITY  enableSuggest.accesskey   "E">
+<!ENTITY  enableSuggest.accesskey   "u">
 
 <!ENTITY  restoreDefaults.label     "Restaurar pesquisas padrão">
 <!ENTITY  restoreDefaults.accesskey "R">

--- a/locale/ru/engineManager.dtd
+++ b/locale/ru/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Название">
 <!ENTITY aliascol.label "Короткое имя">
-<!ENTITY addEngine.accesskey "и">
 <!ENTITY restoreDefault.label "Восстановить поисковой плагин по умолчанию">
 <!ENTITY restoreDefault.accesskey "В">
 <!ENTITY new-folder.label "Новая папка">
@@ -50,8 +49,14 @@
 <!ENTITY remove.accesskey "У">
 <!ENTITY edit.label "Изменить…">
 <!ENTITY edit.accesskey "з">
-<!ENTITY addEngine.label "Плагины для других поисковых систем…">
-<!ENTITY addEngine.accesskey "л">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 <!ENTITY enableSuggest.label "Показывать поисковые предложения">
 <!ENTITY enableSuggest.accesskey "п">
 <!ENTITY restoreDefaults.label "Восстановить набор по умолчанию">

--- a/locale/sr/engineManager.dtd
+++ b/locale/sr/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Назив">
 <!ENTITY aliascol.label "Кључна реч">
-<!ENTITY addEngine.accesskey "Г">
 <!ENTITY restoreDefault.label "Врати изворни претраживач">
 <!ENTITY restoreDefault.accesskey "е">
 <!ENTITY new-folder.label "Нова фасцикла...">
@@ -54,8 +53,14 @@
 <!ENTITY  edit.label                "Уреди кључну реч…">
 <!ENTITY  edit.accesskey            "к">
 
-<!ENTITY  addEngine.label           "Набави још претраживача…">
-<!ENTITY  addEngine.accesskey       "Н">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Прикажи предлоге претраге">
 <!ENTITY  enableSuggest.accesskey   "П">

--- a/locale/tr/engineManager.dtd
+++ b/locale/tr/engineManager.dtd
@@ -1,12 +1,11 @@
 <!ENTITY namecol.label "AD">
 <!ENTITY aliascol.label "Anahtar kelimeler">
-<!ENTITY addEngine.accesskey "G">
-<!ENTITY restoreDefault.label "Varsayılan Arama Motoruna dön">
-<!ENTITY restoreDefault.accesskey "e">
-<!ENTITY new-folder.label "Yeni Klasör">
-<!ENTITY new-folder.accesskey "F">
+<!ENTITY restoreDefault.label "Varsayılan arama motoruna dön">
+<!ENTITY restoreDefault.accesskey "V">
+<!ENTITY new-folder.label "Yeni klasör">
+<!ENTITY new-folder.accesskey "K">
 <!ENTITY new-separator.label "Yeni boşluk">
-<!ENTITY new-separator.accesskey "S">
+<!ENTITY new-separator.accesskey "b">
 <!ENTITY move-engine.label "Taşı...">
 <!ENTITY move-engine.accesskey "M">
 <!ENTITY rename.label "Yeni isim...">
@@ -54,11 +53,17 @@
 <!ENTITY  edit.label                "Anahtar kelime düzenle…">
 <!ENTITY  edit.accesskey            "t">
 
-<!ENTITY  addEngine.label           "Daha fazla arama motoru bul…">
-<!ENTITY  addEngine.accesskey       "a">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Arama önerilerini göster">
-<!ENTITY  enableSuggest.accesskey   "s">
+<!ENTITY  enableSuggest.accesskey   "n">
 
 <!ENTITY  restoreDefaults.label     "Varsayılanları geri getir">
 <!ENTITY  restoreDefaults.accesskey "e">

--- a/locale/uk/engineManager.dtd
+++ b/locale/uk/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "Назва">
 <!ENTITY aliascol.label "Ключове слово">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "Restore Default Engine">
 <!ENTITY restoreDefault.accesskey "e">
 <!ENTITY new-folder.label "Нова папка...">
@@ -54,8 +53,14 @@
 <!ENTITY  edit.label                "Скорочення…">
 <!ENTITY  edit.accesskey            "р">
 
-<!ENTITY  addEngine.label           "Встановити інші засоби пошуку…">
-<!ENTITY  addEngine.accesskey       "і">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "Показувати пошукові припущення">
 <!ENTITY  enableSuggest.accesskey   "П">

--- a/locale/zh-CN/engineManager.dtd
+++ b/locale/zh-CN/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "名字">
 <!ENTITY aliascol.label "关键字">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "恢复默认的搜索引擎">
 <!ENTITY restoreDefault.accesskey "e">
 <!ENTITY new-folder.label "新建文件夹">
@@ -54,11 +53,17 @@
 <!ENTITY  edit.label                "编辑关键字…">
 <!ENTITY  edit.accesskey            "t">
 
-<!ENTITY  addEngine.label           "获取更多搜索引擎…">
-<!ENTITY  addEngine.accesskey       "a">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "显示搜索建议">
-<!ENTITY  enableSuggest.accesskey   "S">
+<!ENTITY  enableSuggest.accesskey   "u">
 
 <!ENTITY  restoreDefaults.label     "恢复默认设置">
 <!ENTITY  restoreDefaults.accesskey "e">

--- a/locale/zh-TW/engineManager.dtd
+++ b/locale/zh-TW/engineManager.dtd
@@ -1,6 +1,5 @@
 <!ENTITY namecol.label "名稱">
 <!ENTITY aliascol.label "關鍵字">
-<!ENTITY addEngine.accesskey "G">
 <!ENTITY restoreDefault.label "回復預設搜尋引擎">
 <!ENTITY restoreDefault.accesskey "e">
 <!ENTITY new-folder.label "新增資料夾">
@@ -54,11 +53,17 @@
 <!ENTITY  edit.label                "編輯關鍵字…">
 <!ENTITY  edit.accesskey            "t">
 
-<!ENTITY  addEngine.label           "更多搜尋引擎…">
-<!ENTITY  addEngine.accesskey       "a">
+<!ENTITY  addEngine.label           "Get search plugins from Mozilla">
+<!ENTITY  addEngine.accesskey       "M">
+<!ENTITY  addEngineMP.label         "Get search plugins from Mycroft Project">
+<!ENTITY  addEngineMP.accesskey     "y">
+<!ENTITY  openGen7is7.label         "7is7 search plugin generator (advanced)">
+<!ENTITY  openGen7is7.accesskey     "7">
+<!ENTITY  openGenR2S.label          "Ready2Search plugin generator (advanced)">
+<!ENTITY  openGenR2S.accesskey      "2">
 
 <!ENTITY  enableSuggest.label       "顯示搜尋建議">
-<!ENTITY  enableSuggest.accesskey   "S">
+<!ENTITY  enableSuggest.accesskey   "u">
 
 <!ENTITY  restoreDefaults.label     "回復為預設值">
 <!ENTITY  restoreDefaults.accesskey "e">

--- a/skin/moveTo.css
+++ b/skin/moveTo.css
@@ -1,0 +1,4 @@
+#moveToDialog {
+  min-width: 25em;
+  min-height: 35em;
+}


### PR DESCRIPTION
This:
- Adds File menu elements to mycroftproject.com (for downloading and creating/uploading search plugins) and to opensearch plugins generators from 7is7.com and ready.to.
- Comments (not removed from code) 'New' submenu from File menu to add 'New folder' and 'New separator' elements to File menu directly.
- Updates all locales for that changes not removing strings of 'New' menu element, removing one duplicate string and in case adjusting access keys of File menu.
- Adds updated spanish locale on the same terms.
- Grows 'Move to' dialog a bit to make it more usable without manually resizing it.
- Suffixes readme with english translation and adds a feature (also for russian text) describing new changes.
